### PR TITLE
fix:  remove schema='NOTIFY' from the JPA annotations applied to Noti…

### DIFF
--- a/src/main/java/uk/ac/ed/notify/entity/NotificationError.java
+++ b/src/main/java/uk/ac/ed/notify/entity/NotificationError.java
@@ -10,7 +10,7 @@ import java.util.Date;
  * Created by rgood on 20/10/2015.
  */
 @Entity
-@Table(name="NOTIFICATION_ERRORS", schema="NOTIFY")
+@Table(name="NOTIFICATION_ERRORS")
 public class NotificationError {
 
     @Id

--- a/src/main/java/uk/ac/ed/notify/entity/UserNotificationAudit.java
+++ b/src/main/java/uk/ac/ed/notify/entity/UserNotificationAudit.java
@@ -10,7 +10,7 @@ import java.util.Date;
  * Created by rgood on 20/10/2015.
  */
 @Entity
-@Table(name="USER_NOTIFICATION_AUDIT", schema="NOTIFY")
+@Table(name="USER_NOTIFICATION_AUDIT")
 public class UserNotificationAudit {
 
     @Id


### PR DESCRIPTION
…ficationError and UserNotificationAudit (already done to other entity classes)

If you use a schema, set the `spring.jpa.properties.hibernate.default_schema` property in `application.properties`.